### PR TITLE
fix(chat): prevent IME composition Enter from auto‑sending edited message

### DIFF
--- a/.changeset/odd-dots-change.md
+++ b/.changeset/odd-dots-change.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": patch
+---
+
+Add detailed configuration options for LiteLLM provider

--- a/.changeset/silly-zebras-applaud.md
+++ b/.changeset/silly-zebras-applaud.md
@@ -1,0 +1,5 @@
+---
+"claude-dev": minor
+---
+
+Releasing memory after every diff edit to help fix grey screen webview crashes

--- a/package.json
+++ b/package.json
@@ -235,44 +235,10 @@
 		"configuration": {
 			"title": "Cline",
 			"properties": {
-				"cline.vsCodeLmModelSelector": {
-					"type": "object",
-					"properties": {
-						"vendor": {
-							"type": "string",
-							"description": "The vendor of the language model (e.g. copilot)"
-						},
-						"family": {
-							"type": "string",
-							"description": "The family of the language model (e.g. gpt-4)"
-						}
-					},
-					"description": "Settings for VSCode Language Model API"
-				},
 				"cline.enableCheckpoints": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enables extension to save checkpoints of workspace throughout the task. Uses git under the hood which may not work well with large workspaces."
-				},
-				"cline.disableBrowserTool": {
-					"type": "boolean",
-					"default": false,
-					"description": "Disables extension from spawning browser session."
-				},
-				"cline.modelSettings.o3Mini.reasoningEffort": {
-					"type": "string",
-					"enum": [
-						"low",
-						"medium",
-						"high"
-					],
-					"default": "medium",
-					"description": "Controls the reasoning effort when using an OpenAI reasoning model. Higher values may result in more thorough but slower responses."
-				},
-				"cline.chromeExecutablePath": {
-					"type": "string",
-					"default": null,
-					"description": "Path to Chrome executable for browser use functionality. If not set, the extension will attempt to find or download it automatically."
 				},
 				"cline.preferredLanguage": {
 					"type": "string",

--- a/proto/browser.proto
+++ b/proto/browser.proto
@@ -40,6 +40,8 @@ message BrowserSettings {
   Viewport viewport = 1;
   optional string remote_browser_host = 2;
   optional bool remote_browser_enabled = 3;
+  optional string chrome_executable_path = 4;
+  optional bool disable_tool_use = 5;
 }
 
 message UpdateBrowserSettingsRequest {
@@ -47,4 +49,6 @@ message UpdateBrowserSettingsRequest {
   Viewport viewport = 2;
   optional string remote_browser_host = 3;
   optional bool remote_browser_enabled = 4;
+  optional string chrome_executable_path = 5;
+  optional bool disable_tool_use = 6;
 }

--- a/src/api/providers/litellm.ts
+++ b/src/api/providers/litellm.ts
@@ -65,7 +65,7 @@ export class LiteLlmHandler implements ApiHandler {
 		const reasoningOn = budgetTokens !== 0 ? true : false
 		const thinkingConfig = reasoningOn ? { type: "enabled", budget_tokens: budgetTokens } : undefined
 
-		let temperature: number | undefined = 0
+		let temperature: number | undefined = this.options.liteLlmModelInfo?.temperature ?? 0
 
 		if (isOminiModel && reasoningOn) {
 			temperature = undefined // Thinking mode doesn't support temperature
@@ -169,7 +169,7 @@ export class LiteLlmHandler implements ApiHandler {
 	getModel() {
 		return {
 			id: this.options.liteLlmModelId || liteLlmDefaultModelId,
-			info: liteLlmModelInfoSaneDefaults,
+			info: this.options.liteLlmModelInfo || liteLlmModelInfoSaneDefaults,
 		}
 	}
 }

--- a/src/core/controller/account/accountLoginClicked.ts
+++ b/src/core/controller/account/accountLoginClicked.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode"
 import crypto from "crypto"
 import { Controller } from "../index"
 import { storeSecret } from "../../storage/state"
-import { String } from "../../../shared/proto/common"
+import { EmptyRequest, String } from "../../../shared/proto/common"
 
 /**
  * Handles the user clicking the login link in the UI.
@@ -12,7 +12,7 @@ import { String } from "../../../shared/proto/common"
  * @param controller The controller instance.
  * @returns The login URL as a string.
  */
-export async function accountLoginClicked(controller: Controller): Promise<String> {
+export async function accountLoginClicked(controller: Controller, unused: EmptyRequest): Promise<String> {
 	// Generate nonce for state validation
 	const nonce = crypto.randomBytes(32).toString("hex")
 	await storeSecret(controller.context, "authNonce", nonce)

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -753,6 +753,7 @@ export class Controller {
 					break
 				case "litellm":
 					await updateGlobalState(this.context, "previousModeModelId", apiConfiguration.liteLlmModelId)
+					await updateGlobalState(this.context, "previousModeModelInfo", apiConfiguration.liteLlmModelInfo)
 					break
 				case "requesty":
 					await updateGlobalState(this.context, "previousModeModelId", apiConfiguration.requestyModelId)
@@ -806,7 +807,8 @@ export class Controller {
 						await updateGlobalState(this.context, "lmStudioModelId", newModelId)
 						break
 					case "litellm":
-						await updateGlobalState(this.context, "liteLlmModelId", newModelId)
+						await updateGlobalState(this.context, "previousModeModelId", apiConfiguration.liteLlmModelId)
+						await updateGlobalState(this.context, "previousModeModelInfo", apiConfiguration.liteLlmModelInfo)
 						break
 					case "requesty":
 						await updateGlobalState(this.context, "requestyModelId", newModelId)

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -67,6 +67,7 @@ export type GlobalStateKey =
 	| "previousModeModelInfo"
 	| "liteLlmBaseUrl"
 	| "liteLlmModelId"
+	| "liteLlmModelInfo"
 	| "liteLlmUsePromptCache"
 	| "qwenApiLine"
 	| "requestyModelId"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -107,6 +107,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		vsCodeLmModelSelector,
 		liteLlmBaseUrl,
 		liteLlmModelId,
+		liteLlmModelInfo,
 		liteLlmUsePromptCache,
 		userInfo,
 		previousModeApiProvider,
@@ -186,6 +187,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 		getGlobalState(context, "vsCodeLmModelSelector") as Promise<vscode.LanguageModelChatSelector | undefined>,
 		getGlobalState(context, "liteLlmBaseUrl") as Promise<string | undefined>,
 		getGlobalState(context, "liteLlmModelId") as Promise<string | undefined>,
+		getGlobalState(context, "liteLlmModelInfo") as Promise<ModelInfo | undefined>,
 		getGlobalState(context, "liteLlmUsePromptCache") as Promise<boolean | undefined>,
 		getGlobalState(context, "userInfo") as Promise<UserInfo | undefined>,
 		getGlobalState(context, "previousModeApiProvider") as Promise<ApiProvider | undefined>,
@@ -304,6 +306,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext) {
 			reasoningEffort,
 			liteLlmBaseUrl,
 			liteLlmModelId,
+			liteLlmModelInfo,
 			liteLlmApiKey,
 			liteLlmUsePromptCache,
 			asksageApiKey,
@@ -386,6 +389,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 		vsCodeLmModelSelector,
 		liteLlmBaseUrl,
 		liteLlmModelId,
+		liteLlmModelInfo,
 		liteLlmApiKey,
 		liteLlmUsePromptCache,
 		qwenApiLine,
@@ -444,6 +448,7 @@ export async function updateApiConfiguration(context: vscode.ExtensionContext, a
 	await updateGlobalState(context, "vsCodeLmModelSelector", vsCodeLmModelSelector)
 	await updateGlobalState(context, "liteLlmBaseUrl", liteLlmBaseUrl)
 	await updateGlobalState(context, "liteLlmModelId", liteLlmModelId)
+	await updateGlobalState(context, "liteLlmModelInfo", liteLlmModelInfo)
 	await updateGlobalState(context, "liteLlmUsePromptCache", liteLlmUsePromptCache)
 	await updateGlobalState(context, "qwenApiLine", qwenApiLine)
 	await updateGlobalState(context, "requestyModelId", requestyModelId)

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -433,6 +433,12 @@ export class DiffViewProvider {
 
 	// close editor if open?
 	async reset() {
+		// releasing memory by clearing the diff editor
+		try {
+			await this.closeAllDiffViews()
+		} catch (error) {
+			console.error("Error closing diff views:", error)
+		}
 		this.editType = undefined
 		this.isEditing = false
 		this.originalContent = undefined

--- a/src/shared/BrowserSettings.ts
+++ b/src/shared/BrowserSettings.ts
@@ -8,6 +8,8 @@ export interface BrowserSettings {
 	// chromeType: "chromium" | "system"
 	remoteBrowserHost?: string
 	remoteBrowserEnabled?: boolean
+	chromeExecutablePath?: string
+	disableToolUse?: boolean
 }
 
 export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
@@ -17,7 +19,9 @@ export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
 	},
 	remoteBrowserEnabled: false,
 	remoteBrowserHost: "http://localhost:9222",
+	chromeExecutablePath: "", // Changed from undefined to empty string
 	// chromeType: "chromium",
+	disableToolUse: false,
 }
 
 export const BROWSER_VIEWPORT_PRESETS = {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -33,6 +33,7 @@ export interface ApiHandlerOptions {
 	liteLlmApiKey?: string
 	liteLlmUsePromptCache?: boolean
 	openAiHeaders?: Record<string, string> // Custom headers for OpenAI requests
+	liteLlmModelInfo?: LiteLLMModelInfo
 	anthropicBaseUrl?: string
 	openRouterApiKey?: string
 	openRouterModelId?: string
@@ -1452,8 +1453,12 @@ export const mistralModels = {
 // LiteLLM
 // https://docs.litellm.ai/docs/
 export type LiteLLMModelId = string
-export const liteLlmDefaultModelId = "gpt-3.5-turbo"
-export const liteLlmModelInfoSaneDefaults: ModelInfo = {
+export const liteLlmDefaultModelId = "anthropic/claude-3-7-sonnet-20250219"
+export interface LiteLLMModelInfo extends ModelInfo {
+	temperature?: number
+}
+
+export const liteLlmModelInfoSaneDefaults: LiteLLMModelInfo = {
 	maxTokens: -1,
 	contextWindow: 128_000,
 	supportsImages: true,
@@ -1462,6 +1467,7 @@ export const liteLlmModelInfoSaneDefaults: ModelInfo = {
 	outputPrice: 0,
 	cacheWritesPrice: 0,
 	cacheReadsPrice: 0,
+	temperature: 0,
 }
 
 // AskSage Models

--- a/src/shared/proto/browser.ts
+++ b/src/shared/proto/browser.ts
@@ -36,6 +36,8 @@ export interface BrowserSettings {
 	viewport?: Viewport | undefined
 	remoteBrowserHost?: string | undefined
 	remoteBrowserEnabled?: boolean | undefined
+	chromeExecutablePath?: string | undefined
+	disableToolUse?: boolean | undefined
 }
 
 export interface UpdateBrowserSettingsRequest {
@@ -43,6 +45,8 @@ export interface UpdateBrowserSettingsRequest {
 	viewport?: Viewport | undefined
 	remoteBrowserHost?: string | undefined
 	remoteBrowserEnabled?: boolean | undefined
+	chromeExecutablePath?: string | undefined
+	disableToolUse?: boolean | undefined
 }
 
 function createBaseBrowserConnectionInfo(): BrowserConnectionInfo {
@@ -382,7 +386,13 @@ export const Viewport: MessageFns<Viewport> = {
 }
 
 function createBaseBrowserSettings(): BrowserSettings {
-	return { viewport: undefined, remoteBrowserHost: undefined, remoteBrowserEnabled: undefined }
+	return {
+		viewport: undefined,
+		remoteBrowserHost: undefined,
+		remoteBrowserEnabled: undefined,
+		chromeExecutablePath: undefined,
+		disableToolUse: undefined,
+	}
 }
 
 export const BrowserSettings: MessageFns<BrowserSettings> = {
@@ -395,6 +405,12 @@ export const BrowserSettings: MessageFns<BrowserSettings> = {
 		}
 		if (message.remoteBrowserEnabled !== undefined) {
 			writer.uint32(24).bool(message.remoteBrowserEnabled)
+		}
+		if (message.chromeExecutablePath !== undefined) {
+			writer.uint32(34).string(message.chromeExecutablePath)
+		}
+		if (message.disableToolUse !== undefined) {
+			writer.uint32(40).bool(message.disableToolUse)
 		}
 		return writer
 	},
@@ -430,6 +446,22 @@ export const BrowserSettings: MessageFns<BrowserSettings> = {
 					message.remoteBrowserEnabled = reader.bool()
 					continue
 				}
+				case 4: {
+					if (tag !== 34) {
+						break
+					}
+
+					message.chromeExecutablePath = reader.string()
+					continue
+				}
+				case 5: {
+					if (tag !== 40) {
+						break
+					}
+
+					message.disableToolUse = reader.bool()
+					continue
+				}
 			}
 			if ((tag & 7) === 4 || tag === 0) {
 				break
@@ -446,6 +478,8 @@ export const BrowserSettings: MessageFns<BrowserSettings> = {
 			remoteBrowserEnabled: isSet(object.remoteBrowserEnabled)
 				? globalThis.Boolean(object.remoteBrowserEnabled)
 				: undefined,
+			chromeExecutablePath: isSet(object.chromeExecutablePath) ? globalThis.String(object.chromeExecutablePath) : undefined,
+			disableToolUse: isSet(object.disableToolUse) ? globalThis.Boolean(object.disableToolUse) : undefined,
 		}
 	},
 
@@ -460,6 +494,12 @@ export const BrowserSettings: MessageFns<BrowserSettings> = {
 		if (message.remoteBrowserEnabled !== undefined) {
 			obj.remoteBrowserEnabled = message.remoteBrowserEnabled
 		}
+		if (message.chromeExecutablePath !== undefined) {
+			obj.chromeExecutablePath = message.chromeExecutablePath
+		}
+		if (message.disableToolUse !== undefined) {
+			obj.disableToolUse = message.disableToolUse
+		}
 		return obj
 	},
 
@@ -472,12 +512,21 @@ export const BrowserSettings: MessageFns<BrowserSettings> = {
 			object.viewport !== undefined && object.viewport !== null ? Viewport.fromPartial(object.viewport) : undefined
 		message.remoteBrowserHost = object.remoteBrowserHost ?? undefined
 		message.remoteBrowserEnabled = object.remoteBrowserEnabled ?? undefined
+		message.chromeExecutablePath = object.chromeExecutablePath ?? undefined
+		message.disableToolUse = object.disableToolUse ?? undefined
 		return message
 	},
 }
 
 function createBaseUpdateBrowserSettingsRequest(): UpdateBrowserSettingsRequest {
-	return { metadata: undefined, viewport: undefined, remoteBrowserHost: undefined, remoteBrowserEnabled: undefined }
+	return {
+		metadata: undefined,
+		viewport: undefined,
+		remoteBrowserHost: undefined,
+		remoteBrowserEnabled: undefined,
+		chromeExecutablePath: undefined,
+		disableToolUse: undefined,
+	}
 }
 
 export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsRequest> = {
@@ -493,6 +542,12 @@ export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsReque
 		}
 		if (message.remoteBrowserEnabled !== undefined) {
 			writer.uint32(32).bool(message.remoteBrowserEnabled)
+		}
+		if (message.chromeExecutablePath !== undefined) {
+			writer.uint32(42).string(message.chromeExecutablePath)
+		}
+		if (message.disableToolUse !== undefined) {
+			writer.uint32(48).bool(message.disableToolUse)
 		}
 		return writer
 	},
@@ -536,6 +591,22 @@ export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsReque
 					message.remoteBrowserEnabled = reader.bool()
 					continue
 				}
+				case 5: {
+					if (tag !== 42) {
+						break
+					}
+
+					message.chromeExecutablePath = reader.string()
+					continue
+				}
+				case 6: {
+					if (tag !== 48) {
+						break
+					}
+
+					message.disableToolUse = reader.bool()
+					continue
+				}
 			}
 			if ((tag & 7) === 4 || tag === 0) {
 				break
@@ -553,6 +624,8 @@ export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsReque
 			remoteBrowserEnabled: isSet(object.remoteBrowserEnabled)
 				? globalThis.Boolean(object.remoteBrowserEnabled)
 				: undefined,
+			chromeExecutablePath: isSet(object.chromeExecutablePath) ? globalThis.String(object.chromeExecutablePath) : undefined,
+			disableToolUse: isSet(object.disableToolUse) ? globalThis.Boolean(object.disableToolUse) : undefined,
 		}
 	},
 
@@ -570,6 +643,12 @@ export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsReque
 		if (message.remoteBrowserEnabled !== undefined) {
 			obj.remoteBrowserEnabled = message.remoteBrowserEnabled
 		}
+		if (message.chromeExecutablePath !== undefined) {
+			obj.chromeExecutablePath = message.chromeExecutablePath
+		}
+		if (message.disableToolUse !== undefined) {
+			obj.disableToolUse = message.disableToolUse
+		}
 		return obj
 	},
 
@@ -584,6 +663,8 @@ export const UpdateBrowserSettingsRequest: MessageFns<UpdateBrowserSettingsReque
 			object.viewport !== undefined && object.viewport !== null ? Viewport.fromPartial(object.viewport) : undefined
 		message.remoteBrowserHost = object.remoteBrowserHost ?? undefined
 		message.remoteBrowserEnabled = object.remoteBrowserEnabled ?? undefined
+		message.chromeExecutablePath = object.chromeExecutablePath ?? undefined
+		message.disableToolUse = object.disableToolUse ?? undefined
 		return message
 	},
 }

--- a/src/test/suite/extension.test.js
+++ b/src/test/suite/extension.test.js
@@ -53,14 +53,4 @@ describe("Extension Tests", function () {
 		await vscode.commands.executeCommand("cline.historyButtonClicked")
 		// Success if no error thrown
 	})
-
-	it("should handle advanced settings configuration", async () => {
-		// Test browser session setting
-		await vscode.workspace.getConfiguration().update("cline.disableBrowserTool", true, true)
-		const updatedConfig = vscode.workspace.getConfiguration("cline")
-		expect(updatedConfig.get("disableBrowserTool")).to.be.true
-
-		// Reset settings
-		await vscode.workspace.getConfiguration().update("cline.disableBrowserTool", undefined, true)
-	})
 })

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1532,14 +1532,6 @@ const ApiOptions = ({
 			{selectedProvider === "litellm" && (
 				<div>
 					<VSCodeTextField
-						value={apiConfiguration?.liteLlmApiKey || ""}
-						style={{ width: "100%" }}
-						type="password"
-						onInput={handleInputChange("liteLlmApiKey")}
-						placeholder="Default: noop">
-						<span style={{ fontWeight: 500 }}>API Key</span>
-					</VSCodeTextField>
-					<VSCodeTextField
 						value={apiConfiguration?.liteLlmBaseUrl || ""}
 						style={{ width: "100%" }}
 						type="url"
@@ -1548,10 +1540,18 @@ const ApiOptions = ({
 						<span style={{ fontWeight: 500 }}>Base URL (optional)</span>
 					</VSCodeTextField>
 					<VSCodeTextField
+						value={apiConfiguration?.liteLlmApiKey || ""}
+						style={{ width: "100%" }}
+						type="password"
+						onInput={handleInputChange("liteLlmApiKey")}
+						placeholder="Default: noop">
+						<span style={{ fontWeight: 500 }}>API Key</span>
+					</VSCodeTextField>
+					<VSCodeTextField
 						value={apiConfiguration?.liteLlmModelId || ""}
 						style={{ width: "100%" }}
 						onInput={handleInputChange("liteLlmModelId")}
-						placeholder={"e.g. gpt-4"}>
+						placeholder={"e.g. anthropic/claude-3-7-sonnet-20250219"}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
 
@@ -1594,6 +1594,119 @@ const ApiOptions = ({
 						</p>
 					</>
 
+					<div
+						style={{
+							color: getAsVar(VSC_DESCRIPTION_FOREGROUND),
+							display: "flex",
+							margin: "10px 0",
+							cursor: "pointer",
+							alignItems: "center",
+						}}
+						onClick={() => setModelConfigurationSelected((val) => !val)}>
+						<span
+							className={`codicon ${modelConfigurationSelected ? "codicon-chevron-down" : "codicon-chevron-right"}`}
+							style={{
+								marginRight: "4px",
+							}}></span>
+						<span
+							style={{
+								fontWeight: 700,
+								textTransform: "uppercase",
+							}}>
+							Model Configuration
+						</span>
+					</div>
+					{modelConfigurationSelected && (
+						<>
+							<VSCodeCheckbox
+								checked={!!apiConfiguration?.liteLlmModelInfo?.supportsImages}
+								onChange={(e: any) => {
+									const isChecked = e.target.checked === true
+									const modelInfo = apiConfiguration?.liteLlmModelInfo
+										? apiConfiguration.liteLlmModelInfo
+										: { ...liteLlmModelInfoSaneDefaults }
+									modelInfo.supportsImages = isChecked
+									setApiConfiguration({
+										...apiConfiguration,
+										liteLlmModelInfo: modelInfo,
+									})
+								}}>
+								Supports Images
+							</VSCodeCheckbox>
+							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
+								<VSCodeTextField
+									value={
+										apiConfiguration?.liteLlmModelInfo?.contextWindow
+											? apiConfiguration.liteLlmModelInfo.contextWindow.toString()
+											: liteLlmModelInfoSaneDefaults.contextWindow?.toString()
+									}
+									style={{ flex: 1 }}
+									onInput={(input: any) => {
+										const modelInfo = apiConfiguration?.liteLlmModelInfo
+											? apiConfiguration.liteLlmModelInfo
+											: { ...liteLlmModelInfoSaneDefaults }
+										modelInfo.contextWindow = Number(input.target.value)
+										setApiConfiguration({
+											...apiConfiguration,
+											liteLlmModelInfo: modelInfo,
+										})
+									}}>
+									<span style={{ fontWeight: 500 }}>Context Window Size</span>
+								</VSCodeTextField>
+								<VSCodeTextField
+									value={
+										apiConfiguration?.liteLlmModelInfo?.maxTokens
+											? apiConfiguration.liteLlmModelInfo.maxTokens.toString()
+											: liteLlmModelInfoSaneDefaults.maxTokens?.toString()
+									}
+									style={{ flex: 1 }}
+									onInput={(input: any) => {
+										const modelInfo = apiConfiguration?.liteLlmModelInfo
+											? apiConfiguration.liteLlmModelInfo
+											: { ...liteLlmModelInfoSaneDefaults }
+										modelInfo.maxTokens = input.target.value
+										setApiConfiguration({
+											...apiConfiguration,
+											liteLlmModelInfo: modelInfo,
+										})
+									}}>
+									<span style={{ fontWeight: 500 }}>Max Output Tokens</span>
+								</VSCodeTextField>
+							</div>
+							<div style={{ display: "flex", gap: 10, marginTop: "5px" }}>
+								<VSCodeTextField
+									value={
+										apiConfiguration?.liteLlmModelInfo?.temperature !== undefined
+											? apiConfiguration.liteLlmModelInfo.temperature.toString()
+											: liteLlmModelInfoSaneDefaults.temperature?.toString()
+									}
+									onInput={(input: any) => {
+										const modelInfo = apiConfiguration?.liteLlmModelInfo
+											? apiConfiguration.liteLlmModelInfo
+											: { ...liteLlmModelInfoSaneDefaults }
+
+										// Check if the input ends with a decimal point or has trailing zeros after decimal
+										const value = input.target.value
+										const shouldPreserveFormat =
+											value.endsWith(".") || (value.includes(".") && value.endsWith("0"))
+
+										modelInfo.temperature =
+											value === ""
+												? liteLlmModelInfoSaneDefaults.temperature
+												: shouldPreserveFormat
+													? value // Keep as string to preserve decimal format
+													: parseFloat(value)
+
+										setApiConfiguration({
+											...apiConfiguration,
+											liteLlmModelInfo: modelInfo,
+										})
+									}}>
+									<span style={{ fontWeight: 500 }}>Temperature</span>
+								</VSCodeTextField>
+							</div>
+						</>
+					)}
 					<p
 						style={{
 							fontSize: "12px",
@@ -2276,7 +2389,7 @@ export function normalizeApiConfiguration(apiConfiguration?: ApiConfiguration): 
 			return {
 				selectedProvider: provider,
 				selectedModelId: apiConfiguration?.liteLlmModelId || "",
-				selectedModelInfo: liteLlmModelInfoSaneDefaults,
+				selectedModelInfo: apiConfiguration?.liteLlmModelInfo || liteLlmModelInfoSaneDefaults,
 			}
 		case "xai":
 			return getProviderData(xaiModels, xaiDefaultModelId)

--- a/webview-ui/src/components/settings/BrowserSettingsSection.tsx
+++ b/webview-ui/src/components/settings/BrowserSettingsSection.tsx
@@ -37,8 +37,22 @@ const ConnectionStatusIndicator = ({
 	)
 }
 
+const CollapsibleContent = styled.div<{ isOpen: boolean }>`
+	overflow: hidden;
+	transition:
+		max-height 0.3s ease-in-out,
+		opacity 0.3s ease-in-out,
+		margin-top 0.3s ease-in-out,
+		visibility 0.3s ease-in-out;
+	max-height: ${({ isOpen }) => (isOpen ? "1000px" : "0")}; // Sufficiently large height
+	opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+	margin-top: ${({ isOpen }) => (isOpen ? "15px" : "0")};
+	visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+`
+
 export const BrowserSettingsSection: React.FC = () => {
 	const { browserSettings } = useExtensionState()
+	const [localChromePath, setLocalChromePath] = useState(browserSettings.chromeExecutablePath || "")
 	const [isCheckingConnection, setIsCheckingConnection] = useState(false)
 	const [connectionStatus, setConnectionStatus] = useState<boolean | null>(null)
 	const [relaunchResult, setRelaunchResult] = useState<{ success: boolean; message: string } | null>(null)
@@ -90,6 +104,14 @@ export const BrowserSettingsSection: React.FC = () => {
 				console.error("Error getting detected Chrome path:", error)
 			})
 	}, [])
+
+	// Sync localChromePath with global state
+	useEffect(() => {
+		if (browserSettings.chromeExecutablePath !== localChromePath) {
+			setLocalChromePath(browserSettings.chromeExecutablePath || "")
+		}
+		// Removed sync for local disableToolUse state
+	}, [browserSettings.chromeExecutablePath, browserSettings.disableToolUse])
 
 	// Debounced connection check function
 	const debouncedCheckConnection = useCallback(
@@ -147,6 +169,8 @@ export const BrowserSettingsSection: React.FC = () => {
 				},
 				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
 				remoteBrowserHost: browserSettings.remoteBrowserHost,
+				chromeExecutablePath: browserSettings.chromeExecutablePath,
+				disableToolUse: browserSettings.disableToolUse,
 			})
 				.then((response) => {
 					if (!response.value) {
@@ -169,6 +193,8 @@ export const BrowserSettingsSection: React.FC = () => {
 			remoteBrowserEnabled: enabled,
 			// If disabling, also clear the host
 			remoteBrowserHost: enabled ? browserSettings.remoteBrowserHost : undefined,
+			chromeExecutablePath: browserSettings.chromeExecutablePath,
+			disableToolUse: browserSettings.disableToolUse,
 		})
 			.then((response) => {
 				if (!response.value) {
@@ -189,6 +215,55 @@ export const BrowserSettingsSection: React.FC = () => {
 			},
 			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
 			remoteBrowserHost: host,
+			chromeExecutablePath: browserSettings.chromeExecutablePath,
+			disableToolUse: browserSettings.disableToolUse,
+		})
+			.then((response) => {
+				if (!response.value) {
+					console.error("Failed to update browser settings")
+				}
+			})
+			.catch((error) => {
+				console.error("Error updating browser settings:", error)
+			})
+	}
+
+	const debouncedUpdateChromePath = useCallback(
+		debounce((newPath: string | undefined) => {
+			BrowserServiceClient.updateBrowserSettings({
+				metadata: {},
+				viewport: {
+					width: browserSettings.viewport.width,
+					height: browserSettings.viewport.height,
+				},
+				remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+				remoteBrowserHost: browserSettings.remoteBrowserHost,
+				chromeExecutablePath: newPath,
+				disableToolUse: browserSettings.disableToolUse,
+			})
+				.then((response) => {
+					if (!response.value) {
+						console.error("Failed to update browser settings for chromeExecutablePath")
+					}
+				})
+				.catch((error) => {
+					console.error("Error updating browser settings for chromeExecutablePath:", error)
+				})
+		}, 500),
+		[browserSettings],
+	)
+
+	const updateChromeExecutablePath = (path: string | undefined) => {
+		BrowserServiceClient.updateBrowserSettings({
+			metadata: {},
+			viewport: {
+				width: browserSettings.viewport.width,
+				height: browserSettings.viewport.height,
+			},
+			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+			remoteBrowserHost: browserSettings.remoteBrowserHost,
+			chromeExecutablePath: path,
+			disableToolUse: browserSettings.disableToolUse,
 		})
 			.then((response) => {
 				if (!response.value) {
@@ -247,6 +322,28 @@ export const BrowserSettingsSection: React.FC = () => {
 		return () => clearInterval(pollInterval)
 	}, [browserSettings.remoteBrowserEnabled, checkConnectionOnce])
 
+	const updateDisableToolUse = (disabled: boolean) => {
+		BrowserServiceClient.updateBrowserSettings({
+			metadata: {},
+			viewport: {
+				width: browserSettings.viewport.width,
+				height: browserSettings.viewport.height,
+			},
+			remoteBrowserEnabled: browserSettings.remoteBrowserEnabled,
+			remoteBrowserHost: browserSettings.remoteBrowserHost,
+			chromeExecutablePath: browserSettings.chromeExecutablePath,
+			disableToolUse: disabled,
+		})
+			.then((response) => {
+				if (!response.value) {
+					console.error("Failed to update disableToolUse setting")
+				}
+			})
+			.catch((error) => {
+				console.error("Error updating disableToolUse setting:", error)
+			})
+	}
+
 	const relaunchChromeDebugMode = () => {
 		setDebugMode(true)
 		setRelaunchResult(null)
@@ -260,121 +357,169 @@ export const BrowserSettingsSection: React.FC = () => {
 	// Determine if we should show the relaunch button
 	const isRemoteEnabled = Boolean(browserSettings.remoteBrowserEnabled)
 	const shouldShowRelaunchButton = isRemoteEnabled && connectionStatus === false
+	const isSubSettingsOpen = !(browserSettings.disableToolUse || false)
 
 	return (
 		<div
 			id="browser-settings-section"
 			style={{ marginBottom: 20, borderTop: "1px solid var(--vscode-panel-border)", paddingTop: 15 }}>
 			<h3 style={{ color: "var(--vscode-foreground)", margin: "0 0 10px 0", fontSize: "14px" }}>Browser Settings</h3>
-			<div style={{ marginBottom: 15 }}>
-				<div style={{ marginBottom: 8 }}>
-					<label style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>Viewport size</label>
-					<VSCodeDropdown
-						style={{ width: "100%" }}
-						value={
-							Object.entries(BROWSER_VIEWPORT_PRESETS).find(([_, size]) => {
-								const typedSize = size as { width: number; height: number }
-								return (
-									typedSize.width === browserSettings.viewport.width &&
-									typedSize.height === browserSettings.viewport.height
-								)
-							})?.[0]
-						}
-						onChange={(event) => handleViewportChange(event as Event)}>
-						{Object.entries(BROWSER_VIEWPORT_PRESETS).map(([name]) => (
-							<VSCodeOption key={name} value={name}>
-								{name}
-							</VSCodeOption>
-						))}
-					</VSCodeDropdown>
-				</div>
+
+			{/* Master Toggle */}
+			<div style={{ marginBottom: isSubSettingsOpen ? 0 : 10 }}>
+				<VSCodeCheckbox
+					checked={browserSettings.disableToolUse || false}
+					onChange={(e) => updateDisableToolUse((e.target as HTMLInputElement).checked)}>
+					Disable browser tool usage
+				</VSCodeCheckbox>
 				<p
 					style={{
 						fontSize: "12px",
 						color: "var(--vscode-descriptionForeground)",
-						margin: 0,
+						margin: "4px 0 0 0px",
 					}}>
-					Set the size of the browser viewport for screenshots and interactions.
+					Prevent Cline from using browser actions (e.g. launch, click, type).
 				</p>
 			</div>
 
-			<div style={{ marginBottom: 0 }}>
-				<div style={{ marginBottom: 4, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-					<VSCodeCheckbox
-						checked={browserSettings.remoteBrowserEnabled}
-						onChange={(e) => updateRemoteBrowserEnabled((e.target as HTMLInputElement).checked)}>
-						Use remote browser connection
-					</VSCodeCheckbox>
-					<ConnectionStatusIndicator
-						isChecking={isCheckingConnection}
-						isConnected={connectionStatus}
-						remoteBrowserEnabled={browserSettings.remoteBrowserEnabled}
-					/>
+			<CollapsibleContent isOpen={isSubSettingsOpen}>
+				<div style={{ marginBottom: 15 }}>
+					<div style={{ marginBottom: 8 }}>
+						<label style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>Viewport size</label>
+						<VSCodeDropdown
+							style={{ width: "100%" }}
+							value={
+								Object.entries(BROWSER_VIEWPORT_PRESETS).find(([_, size]) => {
+									const typedSize = size as { width: number; height: number }
+									return (
+										typedSize.width === browserSettings.viewport.width &&
+										typedSize.height === browserSettings.viewport.height
+									)
+								})?.[0]
+							}
+							onChange={(event) => handleViewportChange(event as Event)}>
+							{Object.entries(BROWSER_VIEWPORT_PRESETS).map(([name]) => (
+								<VSCodeOption key={name} value={name}>
+									{name}
+								</VSCodeOption>
+							))}
+						</VSCodeDropdown>
+					</div>
+					<p
+						style={{
+							fontSize: "12px",
+							color: "var(--vscode-descriptionForeground)",
+							margin: 0,
+						}}>
+						Set the size of the browser viewport for screenshots and interactions.
+					</p>
 				</div>
-				<p
-					style={{
-						fontSize: "12px",
-						color: "var(--vscode-descriptionForeground)",
-						margin: "0 0 6px 0px",
-					}}>
-					Enable Cline to use your Chrome
-					{isBundled ? "(not detected on your machine)" : detectedChromePath ? ` (${detectedChromePath})` : ""}. This
-					requires starting Chrome in debug mode
-					{browserSettings.remoteBrowserEnabled ? (
-						<>
-							{" "}
-							manually (<code>--remote-debugging-port=9222</code>) or using the button below. Enter the host address
-							or leave it blank for automatic discovery.
-						</>
-					) : (
-						"."
-					)}
-				</p>
 
-				{browserSettings.remoteBrowserEnabled && (
-					<div style={{ marginLeft: 0 }}>
-						<VSCodeTextField
-							value={browserSettings.remoteBrowserHost || ""}
-							placeholder="http://localhost:9222"
-							style={{ width: "100%", marginBottom: 8 }}
-							onChange={(e: any) => updateRemoteBrowserHost(e.target.value || undefined)}
+				<div style={{ marginBottom: 0 }}>
+					{" "}
+					{/* This div now contains Remote Connection & Chrome Path */}
+					<div style={{ marginBottom: 4, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+						<VSCodeCheckbox
+							checked={browserSettings.remoteBrowserEnabled}
+							onChange={(e) => updateRemoteBrowserEnabled((e.target as HTMLInputElement).checked)}>
+							Use remote browser connection
+						</VSCodeCheckbox>
+						<ConnectionStatusIndicator
+							isChecking={isCheckingConnection}
+							isConnected={connectionStatus}
+							remoteBrowserEnabled={browserSettings.remoteBrowserEnabled}
 						/>
-
-						{shouldShowRelaunchButton && (
-							<div style={{ display: "flex", gap: "10px", marginBottom: 8, justifyContent: "center" }}>
-								<VSCodeButton style={{ flex: 1 }} disabled={debugMode} onClick={relaunchChromeDebugMode}>
-									{debugMode ? "Relaunching Browser..." : "Relaunch Browser with Debug Mode"}
-								</VSCodeButton>
-							</div>
+					</div>
+					<p
+						style={{
+							fontSize: "12px",
+							color: "var(--vscode-descriptionForeground)",
+							margin: "0 0 6px 0px",
+						}}>
+						Enable Cline to use your Chrome
+						{isBundled ? "(not detected on your machine)" : detectedChromePath ? ` (${detectedChromePath})` : ""}. You
+						can specify a custom path below. Using a remote browser connection requires starting Chrome in debug mode
+						{browserSettings.remoteBrowserEnabled ? (
+							<>
+								{" "}
+								manually (<code>--remote-debugging-port=9222</code>) or using the button below. Enter the host
+								address or leave it blank for automatic discovery.
+							</>
+						) : (
+							"."
 						)}
+					</p>
+					{/* Moved remote-specific settings to appear directly after enabling remote connection */}
+					{browserSettings.remoteBrowserEnabled && (
+						<div style={{ marginLeft: 0, marginTop: 8 }}>
+							<VSCodeTextField
+								value={browserSettings.remoteBrowserHost || ""}
+								placeholder="http://localhost:9222"
+								style={{ width: "100%", marginBottom: 8 }}
+								onChange={(e: any) => updateRemoteBrowserHost(e.target.value || undefined)}
+							/>
 
-						{relaunchResult && (
-							<div
+							{shouldShowRelaunchButton && (
+								<div style={{ display: "flex", gap: "10px", marginBottom: 8, justifyContent: "center" }}>
+									<VSCodeButton style={{ flex: 1 }} disabled={debugMode} onClick={relaunchChromeDebugMode}>
+										{debugMode ? "Relaunching Browser..." : "Relaunch Browser with Debug Mode"}
+									</VSCodeButton>
+								</div>
+							)}
+
+							{relaunchResult && (
+								<div
+									style={{
+										padding: "8px",
+										marginBottom: "8px",
+										backgroundColor: relaunchResult.success ? "rgba(0, 128, 0, 0.1)" : "rgba(255, 0, 0, 0.1)",
+										color: relaunchResult.success
+											? "var(--vscode-terminal-ansiGreen)"
+											: "var(--vscode-terminal-ansiRed)",
+										borderRadius: "3px",
+										fontSize: "11px",
+										whiteSpace: "pre-wrap",
+										wordBreak: "break-word",
+									}}>
+									{relaunchResult.message}
+								</div>
+							)}
+
+							<p
 								style={{
-									padding: "8px",
-									marginBottom: "8px",
-									backgroundColor: relaunchResult.success ? "rgba(0, 128, 0, 0.1)" : "rgba(255, 0, 0, 0.1)",
-									color: relaunchResult.success
-										? "var(--vscode-terminal-ansiGreen)"
-										: "var(--vscode-terminal-ansiRed)",
-									borderRadius: "3px",
-									fontSize: "11px",
-									whiteSpace: "pre-wrap",
-									wordBreak: "break-word",
-								}}>
-								{relaunchResult.message}
-							</div>
-						)}
-
+									fontSize: "12px",
+									color: "var(--vscode-descriptionForeground)",
+									margin: 0,
+								}}></p>
+						</div>
+					)}
+					{/* Chrome Executable Path section now follows remote-specific settings */}
+					<div style={{ marginBottom: 8, marginTop: 8 }}>
+						<label htmlFor="chrome-executable-path" style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>
+							Chrome Executable Path (Optional)
+						</label>
+						<VSCodeTextField
+							id="chrome-executable-path"
+							value={localChromePath}
+							placeholder="e.g., /usr/bin/google-chrome or C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+							style={{ width: "100%" }}
+							onChange={(e: any) => {
+								const newValue = e.target.value || ""
+								setLocalChromePath(newValue)
+								debouncedUpdateChromePath(newValue) // Send "" if empty, not undefined
+							}}
+						/>
 						<p
 							style={{
 								fontSize: "12px",
 								color: "var(--vscode-descriptionForeground)",
-								margin: 0,
-							}}></p>
+								margin: "4px 0 0 0",
+							}}>
+							Leave blank to auto-detect.
+						</p>
 					</div>
-				)}
-			</div>
+				</div>
+			</CollapsibleContent>
 		</div>
 	)
 }


### PR DESCRIPTION

### Description

Closes #3475

Japanese / Chinese IME users reported that pressing **Enter** to *confirm* a
composition while **editing an existing message** immediately triggers
`cline.chat.send`.  
The textarea input is safe because IME Enter emits `keyCode 229 ("Process")`,
but the `contenteditable` editor emits a normal `keyCode 13` **after
`compositionend`**, so the current logic cannot distinguish it.

| File | Change |
|------|--------|
| `webview-ui/src/components/chat/UserMessage.tsx` | add `!e.nativeEvent.isComposing && e.keyCode !== 229` guard before calling `sendMessage()` |
| `webview-ui/src/components/chat/__tests__/UserMessage.ime.test.tsx` | unit test that ensures IME Enter does **not** call `onSend()` |


### Test Procedure

<!-- How did you test this? Are you confident that it will not introduce bugs? If so, why? -->
・Scope is minimal – one Guard (!e.nativeEvent.isComposing && e.keyCode !== 229) in handleKeyDown, no other logic touched.

・isComposing is a standard KeyboardEvent boolean; for browsers that don’t support it, the value is false, so behavior falls back to the original path.

・keyCode 229 fallback keeps legacy Edge/Chromium “Process key” behavior unchanged.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->
Before change
![20250513](https://github.com/user-attachments/assets/c12d906f-f750-4a10-916b-d6e1bb634b4f)
After change
![20250512](https://github.com/user-attachments/assets/ab7e5e19-83fb-45e7-97e3-be43f6fd8b44)


### Additional Notes

<!-- Add any additional notes for reviewers -->
